### PR TITLE
Added new spoofs for microsoft and riot

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,1 @@
+machines/lancache-single.conf

--- a/sites/lancache.conf
+++ b/sites/lancache.conf
@@ -25,7 +25,7 @@ server {
 	listen lancache-riot accept_filter=httpready default;
 	server_name riot _;
 	# DNS entries:
-	# lancache-riot l3cdn.riotgames.com
+	# lancache-riot l3cdn.riotgames.com worldwide.l3cdn.riotgames.com
 	access_log /data/www/logs/lancache-riot-access.log main buffer=128k flush=1m;
 	error_log /data/www/logs/lancache-riot-error.log;
 	include lancache/node-default;
@@ -94,7 +94,7 @@ server {
 	listen lancache-microsoft accept_filter=httpready default;
 	server_name microsoft _;
 	# DNS entries:
-	# lancache-microsoft *.download.windowsupdate.com download.windowsupdate.com dlassets.xboxlive.com *.xboxone.loris.llnwd.net xboxone.vo.llnwd.net images-eds.xboxlive.com xbox-mbr.xboxlive.com
+	# lancache-microsoft *.download.windowsupdate.com download.windowsupdate.com dlassets.xboxlive.com *.xboxone.loris.llnwd.net xboxone.vo.llnwd.net images-eds.xboxlive.com xbox-mbr.xboxlive.com assets1.xboxlive.com.nsatc.net assets1.xboxlive.com
 	access_log /data/www/logs/lancache-microsoft-access.log main buffer=128k flush=1m;
 	error_log /data/www/logs/lancache-microsoft-error.log;
 	include lancache/node-microsoft;
@@ -107,7 +107,7 @@ server {
 	# DNS entries:
 	# lancache-spare1
 	access_log /data/www/logs/lancache-spare1-access.log main;
-	error_log /data/www/logs/lancache-spare1-error.log debug;
+	error_log /data/www/logs/lancache-spare1-error.log;
 	include lancache/node-debug;
 }
 

--- a/vhosts/lancache.conf
+++ b/vhosts/lancache.conf
@@ -1,0 +1,1 @@
+../sites/lancache.conf


### PR DESCRIPTION
Added the following spoofs:
- assets1.xboxlive.com.nsatc.net assets1.xboxlive.com for microsoft.
- worldwide.l3cdn.riotgames.com for riot.

Also:
- Added default links for nginx.conf and vhosts so that a clean checkout just works.
- Remove debug from spare1 logging.
