### PR TITLE
Adding new *.steamcontent.com domain for steam content

### DIFF
--- a/sites/lancache.conf
+++ b/sites/lancache.conf
@@ -14,7 +14,7 @@ server {
 	# content5.steampowered.com content6.steampowered.com content7.steampowered.com
 	# content8.steampowered.com *.hsar.steampowered.com.edgesuite.net
 	# *.akamai.steamstatic.com content-origin.steampowered.com
-	# client-download.steampowered.com
+	# client-download.steampowered.com *.steamcontent.com
 	access_log /data/www/logs/lancache-steam-access.log main buffer=128k flush=1m;
 	error_log /data/www/logs/lancache-steam-error.log;
 	include lancache/node-steam;


### PR DESCRIPTION
My downloads stopped working yesterday.  Looking in a packet dump, I found that they were sourced from randomly numbered content servers, all under *.steamcontent.com.  Adding this domain to my local DNS has restored caching functions with no noted negative effects.
